### PR TITLE
fixed size for big files 

### DIFF
--- a/lib/api/src/getSize.js
+++ b/lib/api/src/getSize.js
@@ -10,7 +10,7 @@ export default function (path, cb) {
     } else {
       let fileLength = 0
       for (let i = 0; i < file.EndofFile.length; i++) {
-        fileLength |= file.EndofFile[i] << (i * 8)
+        fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
       }
       cb(null, fileLength)
     }

--- a/lib/api/src/getSize.js
+++ b/lib/api/src/getSize.js
@@ -10,7 +10,7 @@ export default function (path, cb) {
     } else {
       let fileLength = 0
       for (let i = 0; i < file.EndofFile.length; i++) {
-        fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
+        fileLength += file.EndofFile[i] * Math.pow(2, i * 8)
       }
       cb(null, fileLength)
     }


### PR DESCRIPTION
bitwise operation is limited to 32 bit int.

I was checking the remote size for already transferred files with your getSize function but for large files (in my example a 12 GB video file) it was detecting different size.
