### PR TITLE
Added readdirextra to expose raw file properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ smb2Client.readdir('Windows\\System32', function(err, files){
 });
 ```
 
+### smb2Client.readdirextra ( path, callback )
+Asynchronous readdir(3). Reads the contents of a directory. The callback gets two arguments (err, files) where files is an array of objects representing all files and their properties in the directory, including '.' and '..'.
+
+Example:
+```javascript
+smb2Client.readdirextra('Windows\\System32', function(err, files){
+    if(err) throw err;
+    console.log(files);
+});
+```
+
 ### smb2Client.readFile ( filename, [options], callback )
 - ```filename``` String
 - ```options``` Object

--- a/lib/api/readdirextra.js
+++ b/lib/api/readdirextra.js
@@ -1,0 +1,40 @@
+
+
+var SMB2Forge = require('../tools/smb2-forge')
+  , SMB2Request = SMB2Forge.request
+  ;
+
+/*
+ * readdirextra
+ * =======
+ *
+ * list the file / directory and file data from the path provided:
+ *
+ *  - open the directory
+ *
+ *  - query directory content
+ *
+ *  - close the directory
+ *
+ */
+module.exports = function(path, cb){
+  var connection = this;
+
+  // SMB2 open directory
+  SMB2Request('open', {path:path}, connection, function(err, file){
+    if(err) cb && cb(err);
+    // SMB2 query directory
+    else SMB2Request('query_directory', file, connection, function(err, files){
+      if(err) cb && cb(err);
+      // SMB2 close directory
+      else SMB2Request('close', file, connection, function(err){
+        cb && cb(
+          null
+        , files
+        );
+      });
+    });
+  });
+}
+
+

--- a/lib/smb2.js
+++ b/lib/smb2.js
@@ -98,6 +98,7 @@ proto.writeFile = SMB2Connection.requireConnect(require('./api/writefile'));
 proto.unlink    = SMB2Connection.requireConnect(require('./api/unlink'));
 
 proto.readdir   = SMB2Connection.requireConnect(require('./api/readdir'));
+proto.readdirextra   = SMB2Connection.requireConnect(require('./api/readdirextra'));
 proto.rmdir     = SMB2Connection.requireConnect(require('./api/rmdir'));
 proto.mkdir     = SMB2Connection.requireConnect(require('./api/mkdir'));
 


### PR DESCRIPTION
Was not sure about the naming convention for this particular function,
but I have a great need to read particular file properties on individual
files without loading the entire file into memory.  I added a new
function so as not to break backwards compatibility of this package.  I
did not add any logic to parse these individual file properties, as I
know things like times and dates are stored differently or mean
different things between operating systems.

If there is anything else you need me to do with this branch, or have
suggestions on how to better go about what I am trying to achieve,
please let me know.  Thank you!
