### PR TITLE
fix reading of big files

### DIFF
--- a/lib/api/readfile.js
+++ b/lib/api/readfile.js
@@ -38,7 +38,7 @@ module.exports = function(filename, options, cb){
         ;
       // get file length
       for(var i=0;i<file.EndofFile.length;i++){
-        fileLength |= file.EndofFile[i] << (i*8);
+        fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
       }
       var result = new Buffer(fileLength);
       // callback manager

--- a/lib/api/src/createReadStream.js
+++ b/lib/api/src/createReadStream.js
@@ -24,7 +24,7 @@ class SmbReadableStream extends Readable {
 
     let fileLength = 0
     for (let i = 0; i < file.EndofFile.length; i++) {
-      fileLength |= file.EndofFile[i] << (i * 8)
+      fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
     }
     this.fileLength = fileLength
     this.wait = false

--- a/lib/api/src/createReadStream.js
+++ b/lib/api/src/createReadStream.js
@@ -24,7 +24,7 @@ class SmbReadableStream extends Readable {
 
     let fileLength = 0
     for (let i = 0; i < file.EndofFile.length; i++) {
-      fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
+      fileLength += file.EndofFile[i] * Math.pow(2, i * 8)
     }
     this.fileLength = fileLength
     this.wait = false

--- a/lib/api/src/getSize.js
+++ b/lib/api/src/getSize.js
@@ -10,7 +10,7 @@ export default function (path, cb) {
     } else {
       let fileLength = 0
       for (let i = 0; i < file.EndofFile.length; i++) {
-        fileLength |= file.EndofFile[i] << (i * 8)
+        fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
       }
       cb(null, fileLength)
     }

--- a/lib/api/src/getSize.js
+++ b/lib/api/src/getSize.js
@@ -10,7 +10,7 @@ export default function (path, cb) {
     } else {
       let fileLength = 0
       for (let i = 0; i < file.EndofFile.length; i++) {
-        fileLength += file.EndofFile[i] * Math.pow(2, i * 8);
+        fileLength += file.EndofFile[i] * Math.pow(2, i * 8)
       }
       cb(null, fileLength)
     }


### PR DESCRIPTION
Xen Orchestra reads backup files with this library, and those can be bigger than 2^32 bits in length.

This PR brings the limit to 2^53 bits, but doesn't fix the readfile() api call where the entire file would be put in a buffer.
