### PR TITLE
fix(rename,unlink): fix STATUS_ACCESS_DENIED by passing shareAccess

### DIFF
--- a/lib/api/rename.js
+++ b/lib/api/rename.js
@@ -1,6 +1,6 @@
 var BigInt = require('../tools/bigint');
 var SMB2Request = require('../tools/smb2-forge').request;
-var FILE_OPEN = require('../structures/constants').FILE_OPEN;
+var constants = require('../structures/constants');
 
 /*
  * rename
@@ -31,7 +31,7 @@ module.exports = function rename(oldPath, newPath, options, cb) {
     if (err)
       SMB2Request(
         'create',
-        { path: oldPath, createDisposition: FILE_OPEN },
+        { path: oldPath, createDisposition: constants.FILE_OPEN, shareAccess: constants.FILE_SHARE_DELETE },
         connection,
         function(err, file) {
           if (err) cb && cb(err);

--- a/lib/api/unlink.js
+++ b/lib/api/unlink.js
@@ -1,7 +1,7 @@
 var SMB2Forge = require('../tools/smb2-forge');
 var SMB2Request = SMB2Forge.request;
 var BigInt = require('../tools/bigint');
-
+var constants = require('../structures/constants');
 /*
  * unlink
  * ======
@@ -19,7 +19,7 @@ module.exports = function unlink(path, cb) {
   var connection = this;
 
   // SMB2 open file
-  SMB2Request('create', { path: path }, connection, function(err, file) {
+  SMB2Request('create', { path: path, shareAccess: constants.FILE_SHARE_DELETE }, connection, function(err, file) {
     if (err) cb && cb(err);
     // SMB2 query directory
     else

--- a/lib/messages/create.js
+++ b/lib/messages/create.js
@@ -20,11 +20,18 @@ module.exports = message({
   generate: function(connection, params) {
     var buffer = Buffer.from(params.path, 'ucs2');
     var createDisposition = params.createDisposition;
+    var shareAccess = params.shareAccess;
 
     /* See: https://msdn.microsoft.com/en-us/library/cc246502.aspx
        6 values for CreateDisposition. */
     if (!(createDisposition >= 0 && createDisposition <= 5)) {
       createDisposition = constants.FILE_OVERWRITE_IF;
+    }
+
+    /* See: https://msdn.microsoft.com/en-us/library/cc246502.aspx
+       7 possible values for ShareAccess. */
+    if (!(shareAccess >= 0 && shareAccess <= 7)) {
+      shareAccess = constants.FILE_SHARE_NONE;
     }
 
     return new SMB2Message({
@@ -38,7 +45,7 @@ module.exports = message({
         Buffer: buffer,
         DesiredAccess: desiredAccess,
         FileAttributes: 0x00000080,
-        ShareAccess: 0x00000000,
+        ShareAccess: shareAccess,
         CreateDisposition: createDisposition,
         CreateOptions: 0x00000044,
         NameOffset: 0x0078,

--- a/lib/structures/constants.js
+++ b/lib/structures/constants.js
@@ -14,6 +14,11 @@ module.exports = {
   MAX_READ_LENGTH: 0x00010000,
   MAX_WRITE_LENGTH: 0x00010000 - 0x71,
 
+  FILE_SHARE_NONE: 0x00000000,
+  FILE_SHARE_READ: 0x00000001,
+  FILE_SHARE_WRITE: 0x00000002,
+  FILE_SHARE_DELETE: 0x00000004,
+
   /**
    * 2.2.13.1.1 SMB2 File_Pipe_Printer_Access_Mask
    * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534


### PR DESCRIPTION
This is similar to the issues described in #18 and bchelli/node-smb2#17.

It sets correct ShareAccess values for rename and unlink requests.
See https://msdn.microsoft.com/en-us/library/cc246502.aspx ShareAccess.

ShareAccess was always set to 0x00. For rename and delete requests it is required to include the 0x04 flag.

There might be other situations that require those flags, but I did not check since it was not covert by my use case.

I am not sure if this repo is still active, but I wanted to share my fix with the community anyways.
