### PR TITLE
init connection metadata on reconnection

### DIFF
--- a/lib/smb2.js
+++ b/lib/smb2.js
@@ -31,9 +31,6 @@ var SMB = (module.exports = function(opt) {
   // set default port
   this.port = opt.port || port;
 
-  // set message id
-  this.messageId = 0;
-
   // extract share
   this.share = matches[2];
 
@@ -54,18 +51,6 @@ var SMB = (module.exports = function(opt) {
   this.domain = opt.domain;
   this.username = opt.username;
   this.password = opt.password;
-
-  // set session id
-  this.SessionId = Math.floor(Math.random() * 256) & 0xff;
-
-  // set the process id
-  // https://msdn.microsoft.com/en-us/library/ff470100.aspx
-  this.ProcessId = Buffer.from([
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xfe,
-  ]);
 
   // activate debug mode
   this.debug = opt.debug;

--- a/lib/smb2.js
+++ b/lib/smb2.js
@@ -52,6 +52,15 @@ var SMB = (module.exports = function(opt) {
   this.username = opt.username;
   this.password = opt.password;
 
+  // set the process id
+  // https://msdn.microsoft.com/en-us/library/ff470100.aspx
+  this.ProcessId = Buffer.from([
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xfe,
+  ]);
+
   // activate debug mode
   this.debug = opt.debug;
 

--- a/lib/tools/smb2-connection.js
+++ b/lib/tools/smb2-connection.js
@@ -90,6 +90,21 @@ function connect(connection, cb) {
 
   cb = scheduleAutoClose(connection, cb);
 
+  // set message id
+  connection.messageId = 0;
+
+  // set session id
+  connection.SessionId = Math.floor(Math.random() * 256) & 0xff;
+
+  // set the process id
+  // https://msdn.microsoft.com/en-us/library/ff470100.aspx
+  connection.ProcessId = Buffer.from([
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xff,
+    Math.floor(Math.random() * 256) & 0xfe,
+  ]);
+
   // open TCP socket
   connection.socket.connect(
     connection.port,

--- a/lib/tools/smb2-connection.js
+++ b/lib/tools/smb2-connection.js
@@ -96,15 +96,6 @@ function connect(connection, cb) {
   // set session id
   connection.SessionId = Math.floor(Math.random() * 256) & 0xff;
 
-  // set the process id
-  // https://msdn.microsoft.com/en-us/library/ff470100.aspx
-  connection.ProcessId = Buffer.from([
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xff,
-    Math.floor(Math.random() * 256) & 0xfe,
-  ]);
-
   // open TCP socket
   connection.socket.connect(
     connection.port,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2966,6 +2966,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3290,7 +3291,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3374,6 +3376,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3420,7 +3423,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3686,7 +3690,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2966,7 +2966,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3291,8 +3290,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3376,7 +3374,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3423,8 +3420,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3690,8 +3686,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",


### PR DESCRIPTION
When timeout occurs, new reconnections are not possible (socket is always automatically closed) due to messageid not starting at 0. When socket reconnects, it should be as a new connection from the SMB server perspective.