### PR TITLE
Added TypeScript definitions and fileSize attribute in `createReadStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,81 @@
+import { Readable, Writable } from "stream";
+
+interface ISMB2Options {
+        share: string;
+        username: string;
+        domain: string;
+        password: string;
+        port?: number;
+        packetConcurrrency?: number;
+        autoCloseTimeout?: number;
+    }
+
+    interface ICreateReadStreamOptions {
+        autoClose?: boolean;
+        end?: number;
+        fd?: number;
+        flags?: string;
+        start?: number;
+    }
+
+    interface ICreateWriteStreamOptions {
+        autoClose?: boolean;
+        fd?: number;
+        flags?: string;
+        start?: number;
+    }
+
+    interface SMB2Readable extends Readable {
+        fileSize: number;
+    }
+
+    interface SMB2Writable extends Writable { }
+
+
+    class SMB2 {
+        constructor(options: ISMB2Options);
+        exists(path: string): Promise<boolean>;
+        exists(path: string, cb: (err?: Error, exists?: boolean) => void): void;
+
+        mkdir(path: string, mode?: number): Promise<void>;
+        mkdir(path: string, mode: number, cb: (err?: Error) => void): void;
+        mkdir(path: string, cb: (err?: Error) => void): void;
+
+        readdir(path: string): Promise<string[]>;
+        readdir(path: string, cb: (err?: Error, files?: string[]) => void): void;
+
+        readFile(path: string, options?: { encoding: string | null }): Promise<Buffer | string>;
+        readFile(path: string, cb: (err?: Error, content?: Buffer | string) => void): void;
+        readFile(path: string, options: { encoding: string | null }, cb: (err?: Error, content?: Buffer | string) => void): void;
+
+        rename(oldPath: string, newPath: string, options?: { replace: boolean }): Promise<void>;
+        rename(oldPath: string, newPath: string, cb: (err?: Error) => void): void;
+        rename(oldPath: string, newPath: string, options: { replace: boolean }, cb: (err?: Error) => void): void;
+
+        rmdir(path: string): Promise<void>;
+        rmdir(path: string, cb: (err?: Error) => void): void;
+
+        unlink(path: string): Promise<void>;
+        unlink(path: string, cb: (err?: Error) => void): void;
+
+        writeFile(path: string, data: string | Buffer, options?: { encoding: string | null }): Promise<void>;
+        writeFile(path: string, data: string | Buffer, cb: (err?: Error) => void): void;
+        writeFile(path: string, data: string | Buffer, options: { encoding: string | null }, cb: (err?: Error) => void): void;
+       
+        truncate(path: string, length?: number): Promise<void>;
+        truncate(path: string, length: number, cb: (err?: Error) => void): void;
+        
+        createReadStream(path: string, options?: ICreateReadStreamOptions): Promise<SMB2Readable>;
+        createReadStream(path: string, options: ICreateReadStreamOptions, cb: (err?: Error, readable?: SMB2Readable) => void): void;
+        createReadStream(path: string, cb: (err?: Error, readable?: SMB2Readable) => void): void;
+
+        createWriteStream(path: string, options?: ICreateWriteStreamOptions): Promise<SMB2Writable>;
+        createWriteStream(path: string, options: ICreateWriteStreamOptions, cb: (err?: Error, writable?: SMB2Writable) => void): void;
+        createWriteStream(path: string, cb: (err?: Error, writable?: SMB2Writable) => void): void;
+
+        open(path: string, flags: string, cb: (err?: Error, fd?: number) => void): void;
+        read(fd: number, buffer: Buffer, bufferOffset: number, toRead: number, fileOffset: number, cb: (err?: Error, read?: number, buffer?: Buffer) => void): void;
+        write(fd: number, buffer: Buffer, bufferOffset: number, toWrite: number, fileOffset: number, cb: (err?: Error, written?: number, buffer?: Buffer) => void): void;
+        close(fd: number, cb: (err?: Error) => void): void;
+    }
+    export default SMB2;

--- a/lib/api/createReadStream.js
+++ b/lib/api/createReadStream.js
@@ -24,7 +24,8 @@ module.exports = function createReadStream(path, options, cb) {
     }
 
     var offset = options.start || 0;
-    var end = BigInt.fromBuffer(file.EndofFile).toNumber();
+    var fileSize = BigInt.fromBuffer(file.EndofFile).toNumber();
+    var end = fileSize;
 
     if (options.end < end) {
       end = options.end + 1; // end option is inclusive
@@ -33,6 +34,7 @@ module.exports = function createReadStream(path, options, cb) {
     var close = request.bind(undefined, 'close', file, connection);
 
     var stream = new Readable();
+    stream.fileSize = fileSize;
     if (shouldClose) {
       stream._destroy = function(err, cb) {
         close(function(err2) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "contributors": [
     "Fabrice Marsaud <fabrice.marsaud@vates.fr> (https://github.com/marsaud)"
   ],
+  "types": "index.d.ts",
   "main": "lib/smb2.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for this very useful library! I've added some TypeScript definitions which you might find useful. For range-request related calls, I've also added a `fileSize` property to the `readableStream` object.