### PR TITLE
Typescript: Fixed a typo and added debug parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,9 @@ interface ISMB2Options {
   domain: string;
   password: string;
   port?: number;
-  packetConcurrrency?: number;
+  packetConcurrency?: number;
   autoCloseTimeout?: number;
+  debug?: boolean;
 }
 
 interface ICreateReadStreamOptions {


### PR DESCRIPTION
I've added the debug parameter, which was missing from the docs, but is working. And there was a typo in the `packetConcurrency` flag.