### PR TITLE
feat: stat method and readdir with stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you want the response to include stats, you need to pass the `stats: true`. R
 ```
 [
     {
-        Filename: String,
+        name: String,
         birthtime: Date,
         mtime: Date,
         atime: Date,

--- a/README.md
+++ b/README.md
@@ -108,11 +108,32 @@ smb2Client.mkdir('path\\to\\the\\directory', function(err) {
 });
 ```
 
-> `smb2Client.readdir ( path, callback )`
+> `smb2Client.readdir ( path, [options], callback )`
+
+- `path` String
+- `options` Object
+  - `encoding` String | Null default = null
+- `callback` Function
 
 Asynchronous `readdir(3)`: reads the contents of a directory.
 
 The result is an array of the names of the files in the directory excluding `'.'` and `'..'`.
+
+If you want the response to include stats, you need to pass the `stats: true`. Response will be an Array of this form:
+
+```
+[
+    {
+        Filename: String,
+        birthtime: Date,
+        mtime: Date,
+        atime: Date,
+        ctime: Date,
+        isDirectory(): boolean
+    },
+...
+]
+```
 
 Example:
 
@@ -121,6 +142,25 @@ smb2Client.readdir('Windows\\System32', function(err, files) {
   if (err) throw err;
   console.log(files);
 });
+```
+
+> `smb2Client.stat ( path, callback )`
+
+- `path` String
+- `callback` Function
+
+Asynchronous `stat`: query stats of a directory or file.
+
+Response will be an object with the following structure :
+
+```
+{
+    birthtime: Date,
+    mtime: Date,
+    atime: Date,
+    ctime: Date,
+    isDirectory(): boolean
+}
 ```
 
 > `smb2Client.readFile ( path, [options], callback )`

--- a/lib/api/readdir.js
+++ b/lib/api/readdir.js
@@ -25,7 +25,7 @@ module.exports = function readdir(path, options, cb) {
   var mapping = options.stats
     ? function(v) {
         var obj = stats(v);
-        obj.filename = v.Filename;
+        obj.name = v.Filename;
         return obj;
       }
     : function(v) {

--- a/lib/api/readdir.js
+++ b/lib/api/readdir.js
@@ -1,6 +1,6 @@
 var SMB2Forge = require('../tools/smb2-forge');
 var SMB2Request = SMB2Forge.request;
-
+var stats = require('../tools/stats.js');
 /*
  * readdir
  * =======
@@ -14,33 +14,47 @@ var SMB2Request = SMB2Forge.request;
  *  - close the directory
  *
  */
-module.exports = function readdir(path, cb) {
+module.exports = function readdir(path, options, cb) {
   var connection = this;
+
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+
+  var mapping = function(v) {
+    // get the filename only
+    return v.Filename;
+  };
+
+  if (options.stats) {
+    mapping = function(v) {
+      var obj = stats(v);
+      obj.filename = v.Filename;
+      return obj;
+    };
+  }
 
   function queryDirectory(filesBatch, file, connection, cb) {
     SMB2Request('query_directory', file, connection, function(err, files) {
       if (err) {
-        if(err.code === 'STATUS_NO_MORE_FILES') {
+        if (err.code === 'STATUS_NO_MORE_FILES') {
           cb(null, filesBatch);
         } else {
           cb(err);
         }
-      
       } else {
         filesBatch.push(
           files
-          .map(function(v) {
-            // get the filename only
-            return v.Filename;
-          }) 
-          .filter(function(v) {
-            // remove '.' and '..' values
-            return v !== '.' && v !== '..';
-          })
+            .filter(function(v) {
+              // remove '.' and '..' values
+              return v.Filename !== '.' && v.Filename !== '..';
+            })
+            .map(mapping)
         );
         queryDirectory(filesBatch, file, connection, cb);
-      } 
-    });  
+      }
+    });
   }
 
   function openDirectory(path, connection, cb) {
@@ -54,18 +68,17 @@ module.exports = function readdir(path, cb) {
   }
 
   function closeDirectory(file, connection, cb) {
-    // SMB2 query directory  
+    // SMB2 query directory
     SMB2Request('close', file, connection, function(err, res) {
       if (err) {
-        if(err.code !== 'STATUS_FILE_CLOSED') {
+        if (err.code !== 'STATUS_FILE_CLOSED') {
           cb(err);
         }
       }
       // SMB2 close directory
-      cb(null, res);    
+      cb(null, res);
     });
   }
-
 
   openDirectory(path, connection, function(err, file) {
     var totalFiles = [];
@@ -83,10 +96,10 @@ module.exports = function readdir(path, cb) {
             } else {
               totalFiles = [].concat(...filesBatch);
               cb(null, totalFiles);
-            }              
+            }
           });
-        }          
-      })
+        }
+      });
     }
   });
 };

--- a/lib/api/readdir.js
+++ b/lib/api/readdir.js
@@ -22,18 +22,15 @@ module.exports = function readdir(path, options, cb) {
     options = {};
   }
 
-  var mapping = function(v) {
-    // get the filename only
-    return v.Filename;
-  };
-
-  if (options.stats) {
-    mapping = function(v) {
-      var obj = stats(v);
-      obj.filename = v.Filename;
-      return obj;
-    };
-  }
+  var mapping = options.stats
+    ? function(v) {
+        var obj = stats(v);
+        obj.filename = v.Filename;
+        return obj;
+      }
+    : function(v) {
+        return v.Filename;
+      };
 
   function queryDirectory(filesBatch, file, connection, cb) {
     SMB2Request('query_directory', file, connection, function(err, files) {

--- a/lib/api/stat.js
+++ b/lib/api/stat.js
@@ -4,7 +4,7 @@ var request = require('../tools/smb2-forge').request;
 module.exports = function stat(path, cb) {
   var connection = this;
   request('open', { path: path }, connection, function(err, file) {
-    if (err !== null) {
+    if (err != null) {
       return cb(err);
     }
     request('close', file, connection, function() {

--- a/lib/api/stat.js
+++ b/lib/api/stat.js
@@ -1,28 +1,14 @@
-var BigInt = require('../tools/bigint');
-var convert = require('../tools/convert_time');
+var stats = require('../tools/stats.js');
 var request = require('../tools/smb2-forge').request;
 
 module.exports = function stat(path, cb) {
   var connection = this;
   request('open', { path: path }, connection, function(err, file) {
-    if (err != null) {
+    if (err !== null) {
       return cb(err);
     }
     request('close', file, connection, function() {
-      cb(null, {
-        CreationTime: convert(BigInt.fromBuffer(file.CreationTime).toNumber()),
-        LastAccessTime: convert(
-          BigInt.fromBuffer(file.LastAccessTime).toNumber()
-        ),
-        LastWriteTime: convert(
-          BigInt.fromBuffer(file.LastWriteTime).toNumber()
-        ),
-        ChangeTime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
-        size: BigInt.fromBuffer(file.AllocationSize).toNumber(),
-        isDirectory: function() {
-          return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
-        },
-      });
+      cb(null, stats(file));
     });
   });
 };

--- a/lib/api/stat.js
+++ b/lib/api/stat.js
@@ -1,0 +1,28 @@
+var BigInt = require('../tools/bigint');
+var convert = require('../tools/convert_time');
+var request = require('../tools/smb2-forge').request;
+
+module.exports = function stat(path, cb) {
+  var connection = this;
+  request('open', { path: path }, connection, function(err, file) {
+    if (err != null) {
+      return cb(err);
+    }
+    request('close', file, connection, function() {
+      cb(null, {
+        CreationTime: convert(BigInt.fromBuffer(file.CreationTime).toNumber()),
+        LastAccessTime: convert(
+          BigInt.fromBuffer(file.LastAccessTime).toNumber()
+        ),
+        LastWriteTime: convert(
+          BigInt.fromBuffer(file.LastWriteTime).toNumber()
+        ),
+        ChangeTime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
+        size: BigInt.fromBuffer(file.AllocationSize).toNumber(),
+        isDirectory: function() {
+          return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
+        },
+      });
+    });
+  });
+};

--- a/lib/smb2.js
+++ b/lib/smb2.js
@@ -113,6 +113,8 @@ proto.getSize = autoPromise(
   SMB2Connection.requireConnect(require('./api/getSize'))
 );
 
+proto.stat = autoPromise(SMB2Connection.requireConnect(require('./api/stat')));
+
 proto.open = autoPromise(SMB2Connection.requireConnect(require('./api/open')));
 proto.read = autoPromise(require('./api/read'), function(bytesRead, buffer) {
   return {

--- a/lib/structures/constants.js
+++ b/lib/structures/constants.js
@@ -30,4 +30,11 @@ module.exports = {
   READ_CONTROL: 0x00020000,
   SYNCHRONIZE: 0x00100000,
   WRITE_DAC: 0x00040000,
+
+  /**
+   * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9
+   * FileAttributes values
+   */
+
+  DIRECTORY: 16,
 };

--- a/lib/tools/convert_time.js
+++ b/lib/tools/convert_time.js
@@ -1,6 +1,7 @@
+// https://stackoverflow.com/questions/6161776/convert-windows-filetime-to-second-in-unix-linux
+var winTicks = 10000000;
+var uEpoch = 11644473600;
 module.exports = function convert(time) {
-  var winTicks = 10000000;
-  var uEpoch = 11644473600;
   var unixTime = time / winTicks - uEpoch;
   return new Date(unixTime * 1000);
 };

--- a/lib/tools/convert_time.js
+++ b/lib/tools/convert_time.js
@@ -1,0 +1,6 @@
+module.exports = function convert(time) {
+  var winTicks = 10000000;
+  var uEpoch = 11644473600;
+  var unixTime = time / winTicks - uEpoch;
+  return new Date(unixTime * 1000);
+};

--- a/lib/tools/stats.js
+++ b/lib/tools/stats.js
@@ -7,7 +7,7 @@ module.exports = function(file) {
     atime: convert(BigInt.fromBuffer(file.LastAccessTime).toNumber()),
     mtime: convert(BigInt.fromBuffer(file.LastWriteTime).toNumber()),
     ctime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
-    size: BigInt.fromBuffer(file.AllocationSize).toNumber(),
+    size: BigInt.fromBuffer(file.EndofFile).toNumber(),
     isDirectory: function() {
       return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
     },

--- a/lib/tools/stats.js
+++ b/lib/tools/stats.js
@@ -1,0 +1,15 @@
+var convert = require('./convert_time');
+var BigInt = require('./bigint');
+
+module.exports = function(file) {
+  return {
+    birthtime: convert(BigInt.fromBuffer(file.CreationTime).toNumber()),
+    atime: convert(BigInt.fromBuffer(file.LastAccessTime).toNumber()),
+    mtime: convert(BigInt.fromBuffer(file.LastWriteTime).toNumber()),
+    ctime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
+    size: BigInt.fromBuffer(file.AllocationSize).toNumber(),
+    isDirectory: function() {
+      return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
+    },
+  };
+};

--- a/lib/tools/stats.js
+++ b/lib/tools/stats.js
@@ -1,7 +1,8 @@
 var convert = require('./convert_time');
 var BigInt = require('./bigint');
+var DIRECTORY = require('../structures/constants').DIRECTORY;
 
-module.exports = function(file) {
+module.exports = function stat(file) {
   return {
     birthtime: convert(BigInt.fromBuffer(file.CreationTime).toNumber()),
     atime: convert(BigInt.fromBuffer(file.LastAccessTime).toNumber()),
@@ -9,9 +10,11 @@ module.exports = function(file) {
     ctime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
     size: BigInt.fromBuffer(file.EndofFile).toNumber(),
     isDirectory: function() {
-      if (typeof file.FileAttributes === 'number')
-        return file.FileAttributes === 16;
-      return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
+      var attr = file.FileAttributes;
+      if (typeof attr !== 'number') {
+        attr = BigInt.fromBuffer(attr).toNumber();
+      }
+      return attr === DIRECTORY;
     },
   };
 };

--- a/lib/tools/stats.js
+++ b/lib/tools/stats.js
@@ -9,6 +9,8 @@ module.exports = function(file) {
     ctime: convert(BigInt.fromBuffer(file.ChangeTime).toNumber()),
     size: BigInt.fromBuffer(file.EndofFile).toNumber(),
     isDirectory: function() {
+      if (typeof file.FileAttributes === 'number')
+        return file.FileAttributes === 16;
       return BigInt.fromBuffer(file.FileAttributes).toNumber() === 16;
     },
   };

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ const Smb2 = require('../');
 
 const dir = 'smb2-tests-' + Date.now();
 const file = dir + '\\file.txt';
+const file2 = dir + '\\file2.txt';
 const data = Buffer.from(
   Array.from({ length: 1024 }, function() {
     return Math.floor(Math.random() * 256);
@@ -38,21 +39,90 @@ const tests = {
       t.same(result.isDirectory(), false);
     });
   },
+  getSize: function(client) {
+    return client.getSize(file).then(function(result) {
+      t.same(result, data.length);
+    });
+  },
+  exists: function(client) {
+    return client
+      .exists(file)
+      .then(function(result) {
+        t.same(result, true);
+        return client.exists(file2);
+      })
+      .then(function(result) {
+        t.same(result, false);
+      });
+  },
   statDir: function(client) {
     return client.stat(dir).then(function(result) {
       t.same(result.size, 0);
       t.same(result.isDirectory(), true);
     });
   },
+  readdir: function(client) {
+    return client.readdir(dir).then(function(result) {
+      t.same(result.length, 1);
+    });
+  },
+  readdirWithStats: function(client) {
+    return client.readdir(dir, { stats: true }).then(function(result) {
+      t.same(result.length, 1);
+      t.same(result[0].filename, 'file.txt');
+      t.same(result[0].size, data.length);
+      t.same(result[0].isDirectory(), false);
+    });
+  },
+  rename: function(client) {
+    return client
+      .rename(file, file2)
+      .then(function() {
+        return client.readdir(dir);
+      })
+      .then(function(result) {
+        t.same(result.length, 1);
+        t.same(result[0], 'file2.txt');
+      })
+      .then(function() {
+        return client.rename(file2, file);
+      })
+      .then(function() {
+        return client.readdir(dir);
+      })
+      .then(function(result) {
+        t.same(result.length, 1);
+        t.same(result[0], 'file.txt');
+      });
+  },
+  truncate: function(client) {
+    return client
+      .truncate(file, 10)
+      .then(function() {
+        return client.stat(file);
+      })
+      .then(function(result) {
+        t.same(result.size, 10);
+      });
+  },
   unlink: function(client) {
     return client.unlink(file);
   },
   'open new file and write': asyncFn(function*(client) {
-    const fd = yield client.open(file, 'w');
+    var fd = yield client.open(file, 'w');
+    try {
+      t.same(yield client.write(fd, data, undefined, undefined, 0), {
+        bytesWritten: data.length,
+        buffer: data,
+      });
+    } finally {
+      yield client.close(fd);
+    }
+    fd = yield client.open(file, 'r');
     try {
       try {
-        t.same(yield client.write(fd, data, undefined, undefined, 0), {
-          bytesWritten: data.length,
+        t.same(yield client.read(fd, Buffer.alloc(1024), 0, 1024, 0), {
+          bytesRead: data.length,
           buffer: data,
         });
       } finally {

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,18 @@ const tests = {
       t.same(result, data);
     });
   },
+  statFile: function(client) {
+    return client.stat(file).then(function(result) {
+      t.same(result.size, data.length);
+      t.same(result.isDirectory(), false);
+    });
+  },
+  statDir: function(client) {
+    return client.stat(dir).then(function(result) {
+      t.same(result.size, 0);
+      t.same(result.isDirectory(), true);
+    });
+  },
   unlink: function(client) {
     return client.unlink(file);
   },


### PR DESCRIPTION
took the idea from https://github.com/Node-SMB/marsaud-smb2/issues/53#issuecomment-653601498

returns an object with the following structure:

{
  CreationTime: 2020-07-21T04:52:14.186Z,
  LastAccessTime: 2020-08-05T13:39:15.848Z,
  LastWriteTime: 2020-07-21T04:52:14.186Z,
  ChangeTime: 2020-07-21T04:52:14.186Z,
  size: 1048576,
  isDirectory: [Function: isDirectory]
}

Probably a good idea to standarize the return to a stats object (same as [ssh2 package](https://github.com/mscdex/ssh2-streams/blob/8de25ea69a76dbf1c34e578e42571e97de926ac0/lib/sftp.js#L2638), but hard to map smb return response to it.

Full response:

{
  StructureSize: <Buffer 59 00>,
  OplockLevel: <Buffer 00>,
  Flags: <Buffer 00>,
  CreateAction: <Buffer 01 00 00 00>,
  CreationTime: <Buffer be 2b e4 35 46 81 d6 01>,
  LastAccessTime: <Buffer fe c7 e4 35 46 81 d6 01>,
  LastWriteTime: <Buffer be 2b e4 35 46 81 d6 01>,
  ChangeTime: <Buffer be 2b e4 35 46 81 d6 01>,
  AllocationSize: <Buffer 00 00 00 00 00 00 00 00>,
  EndofFile: <Buffer 00 00 00 00 00 00 00 00>,
  FileAttributes: <Buffer 10 00 00 00>,
  Reserved2: <Buffer 00 00 00 00>,
  FileId: <Buffer ed cf 17 a3 00 00 00 00 b0 d4 a6 32 00 00 00 00>,
  CreateContextsOffset: <Buffer 00 00 00 00>,
  CreateContextsLength: <Buffer 00 00 00 00>,
  Buffer: <Buffer >
}