### PR TITLE
feat(typedefs): add disconnect method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ interface SMB2Writable extends Writable {}
 
 declare class SMB2 {
   constructor(options: ISMB2Options);
+  disconnect(): void;
   exists(path: string): Promise<boolean>;
   exists(path: string, cb: (err?: Error, exists?: boolean) => void): void;
 


### PR DESCRIPTION
I've added the `disconnect()` method, which was missing on the typedefs.