### PR TITLE
fix(createReadStream): implement backpressure

### DIFF
--- a/lib/api/createReadStream.js
+++ b/lib/api/createReadStream.js
@@ -45,7 +45,35 @@ module.exports = function createReadStream(path, options, cb) {
         });
       };
     }
+
     var running = false;
+
+    function read(size) {
+      request(
+        'read',
+        {
+          FileId: file.FileId,
+          Length: Math.min(MAX_READ_LENGTH, size, end - offset),
+          Offset: new BigInt(8, offset).toBuffer(),
+        },
+        connection,
+        function(err, content) {
+          if (err != null) {
+            return process.nextTick(stream.emit.bind(stream, 'error', err));
+          }
+
+          offset += content.length;
+          if (stream.push(content)) {
+            if (end - offset === 0) {
+              running = false;
+              stream.push(null);
+            } else read(size);
+          } else {
+            running = false;
+          }
+        }
+      );
+    }
     stream._read = function(size) {
       if (running) {
         return;
@@ -57,27 +85,10 @@ module.exports = function createReadStream(path, options, cb) {
               stream.push(null);
             })
           : stream.push(null);
+      } else {
+        running = true;
+        read(size);
       }
-
-      running = true;
-      request(
-        'read',
-        {
-          FileId: file.FileId,
-          Length: Math.min(MAX_READ_LENGTH, size, end - offset),
-          Offset: new BigInt(8, offset).toBuffer(),
-        },
-        connection,
-        function(err, content) {
-          running = false;
-          if (err != null) {
-            return process.nextTick(stream.emit.bind(stream, 'error', err));
-          }
-
-          offset += content.length;
-          stream.push(content);
-        }
-      );
     };
     cb(null, stream);
   }


### PR DESCRIPTION
continue reading until stream.push returns false, as specified by [streams API](https://nodejs.org/api/stream.html#stream_readable_read_size_1)

I was running into race conditions where streams were being closed twice on end (instead of just once). Implementing the backpressure from Node solved the issue.